### PR TITLE
Added missing redirection link to sell-online page in the footer section of the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,7 +698,7 @@
       <div>
 
         <ul>
-          <li><a href=""><i class="bi bi-briefcase-fill"></i> Become a seller</a></li>
+          <li><a href="pages/Sell_Online/sell_online.html"><i class="bi bi-briefcase-fill"></i> Become a seller</a></li>
           <li><a href="./Gift Card/GiftCard.html"><i class="bi bi-gift-fill"></i> Gift Cards</a></li>
           <li><a href=""><i class="bi bi-question-circle-fill"></i> Help Center</a></li>
           <div>


### PR DESCRIPTION
## Related Issue
Feat: Adding "Become a Seller" Page #493

## Description

Added missing redirection link to sell-online page in the footer section of the homepage

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
Solved a minor redirection issue.