### PR TITLE
[BUG]: Fixed the alignment of image in topdeals section

### DIFF
--- a/topdeals.html
+++ b/topdeals.html
@@ -53,7 +53,8 @@
         }
         .swiper-slide img {
             width: 100%;
-            height: 300px;
+            height: 100%;
+            object-fit: cover;
             transition: 0.5s;
             border-bottom: 1px solid rgb(226, 226, 226);
         }


### PR DESCRIPTION
## Related Issue
Fixes #1013 

## Description
Updated CSS for images in Swiper slider to ensure uniform sizing across all slides. This was achieved by setting the width and height of the images to 100% and using object-fit: cover.

## Type of PR
- [X] Bug fix

## Screenshots / videos (if applicable)

**Before**
![Screenshot 2024-06-04 091606](https://github.com/arghadipmanna101/Flipkart_Clone/assets/118645569/409db284-ded3-4aa7-8e4e-d52637d8d247)

**After**
![Screenshot 2024-06-04 090530](https://github.com/arghadipmanna101/Flipkart_Clone/assets/118645569/f606a8a9-f01a-4177-8d4e-6b0585849e18)


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.

## Additional context:
This change improves the visual consistency of the Swiper slider by ensuring all images are the same size.
Kindly label it under gssoc with respective labels