### PR TITLE
Fix: Add margin between FAQ and Contact sections on the Home page

### DIFF
--- a/css/contactus.css
+++ b/css/contactus.css
@@ -91,7 +91,7 @@ form label {
     align-items: center;
     width: 85vw;
     border-radius: 20px;
-    margin-bottom: 50px !important;
+    margin-block: 50px !important;
     background-image: linear-gradient(to right, red 1%, orange 99%) !important;
 }
 


### PR DESCRIPTION


## Related Issue
Closes #1606 

## Description
This pull request addresses the issue where the FAQ and Contact sections on the Home (Landing page) were positioned too closely together. I have added consistent margin between the two sections to create a clear visual separation, enhancing readability and improving the overall user experience.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![flipkartadjustment](https://github.com/user-attachments/assets/f9e9303a-0910-4f08-af2d-5777fe3ab8f3)



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.

## Additional context:
None.

---

Replace #1606 .
